### PR TITLE
Use a copy of KSP's GUI skin

### DIFF
--- a/KerbalAlarmClock/Resources.cs
+++ b/KerbalAlarmClock/Resources.cs
@@ -540,7 +540,7 @@ namespace KerbalAlarmClock
         internal static void InitSkins()
         {
             DefUnitySkin = GUI.skin;
-            DefKSPSkin = HighLogic.Skin;
+            DefKSPSkin = (GUISkin)GUISkin.Instantiate(HighLogic.Skin);
 
             SetSkin(KerbalAlarmClock.settings.SelectedSkin);
         }


### PR DESCRIPTION
Hello, this small patch stops KAC affecting the fonts used by the rest of KSP's
UI by making a copy of KSP's skin. For example, currently it causes the FAR
analysis window to be sized incorrectly:
![ui](https://cloud.githubusercontent.com/assets/10180062/7618320/4b94a7a8-f9a9-11e4-8499-9c9042f233b7.png)
