### PR TITLE
Add compatibility for EditorTime

### DIFF
--- a/KerbalAlarmClock/KerbalAlarmClock_GameState.cs
+++ b/KerbalAlarmClock/KerbalAlarmClock_GameState.cs
@@ -197,8 +197,13 @@ namespace KerbalAlarmClock
             else
                KACWorkerGameState.CurrentSaveGameName = "";
 
-            try {KACWorkerGameState.CurrentTime.UT = Planetarium.GetUniversalTime(); }
-            catch (Exception) { }
+            try {
+				if (HighLogic.LoadedSceneIsEditor) {
+					KACWorkerGameState.CurrentTime.UT = HighLogic.CurrentGame.flightState.universalTime;
+				} else {
+					KACWorkerGameState.CurrentTime.UT = Planetarium.GetUniversalTime();
+				}
+			} catch (Exception) { }
             //if (Planetarium.fetch!=null)KACWorkerGameState.CurrentTime.UT = Planetarium.GetUniversalTime();
 
             try


### PR DESCRIPTION
This allows KAC alarms to fire properly when EditorTime is present and
causing time to pass while in the VAB/SPH.

There is one known issue with this change: if the alarm is set to pause
the game, time stops correctly, but the VAB/SPH camera breaks and no
longer moves or rotates. Exiting/re-entering the building is sufficient
to get things working again.