### PR TITLE
Update KerbalAlarmClock.version Min KSP Version

### DIFF
--- a/KerbalAlarmClock/KerbalAlarmClock.version
+++ b/KerbalAlarmClock/KerbalAlarmClock.version
@@ -16,7 +16,7 @@
   "KSP_VERSION_MIN": {
     "MAJOR": 1,
     "MINOR": 1,
-    "PATCH": 0
+    "PATCH": 3
   },
   "KSP_VERSION_MAX": {
     "MAJOR": 1,


### PR DESCRIPTION
Set KSP_VERSION_MIN to match request KSP-CKAN/NetKAN#4283
We have an update to fix v3.7.0.0 - v3.7.1.x.
