### PR TITLE
Use alternate method for getting KACType

### DIFF
--- a/KerbalAlarmClock/API/KACWrapper.cs
+++ b/KerbalAlarmClock/API/KACWrapper.cs
@@ -75,10 +75,11 @@ namespace KACWrapper
             LogFormatted("Attempting to Grab KAC Types...");
 
             //find the base type
-            KACType = AssemblyLoader.loadedAssemblies
-                .Select(a => a.assembly.GetExportedTypes())
-                .SelectMany(t => t)
-                .FirstOrDefault(t => t.FullName == "KerbalAlarmClock.KerbalAlarmClock");
+            AssemblyLoader.loadedAssemblies.TypeOperation(t =>
+            {
+                if (t.FullName == "KerbalAlarmClock.KerbalAlarmClock")
+                    KACType = t;
+            });
 
             if (KACType == null)
             {


### PR DESCRIPTION
I broke your wrapper with an upcoming change to Contract Configurator (for 1.2).  Sorry!

Here's the error that having the two mods, plus someone calling the wrapper (for interest's sake):
```
NotSupportedException: The invoked member is not supported in a dynamic module.
  at System.Reflection.Emit.AssemblyBuilder.GetExportedTypes () [0x00000] in <filename unknown>:0 
  at DF.KACWrapper+<>c.<InitKACWrapper>b__15_0 (.LoadedAssembly a) [0x00000] in <filename unknown>:0 
```