### PR TITLE
Make MaxTooltipTime user configurable

### DIFF
--- a/KerbalAlarmClock/KerbalAlarmClock_Window.cs
+++ b/KerbalAlarmClock/KerbalAlarmClock_Window.cs
@@ -42,13 +42,14 @@ namespace KerbalAlarmClock
 
         private void DrawToolTip()
         {
-            if (strToolTipText != "" && (fltTooltipTime < settings.MaxToolTipTimeFloat))
+            //reset display time if text changed
+            if (strToolTipText != strLastTooltipText)
+                fltTooltipTime = Time.unscaledTime + settings.MaxToolTipTimeFloat;
+            if (strToolTipText != "" && (Time.unscaledTime <= fltTooltipTime))
             {
                 GUIContent contTooltip = new GUIContent(strToolTipText);
                 if (!blnToolTipDisplayed || (strToolTipText != strLastTooltipText))
                 {
-                    //reset display time if text changed
-                    fltTooltipTime = 0f;
                     //Calc the size of the Tooltip
                     rectToolTipPosition = new Rect(Event.current.mousePosition.x, Event.current.mousePosition.y + intTooltipVertOffset, 0, 0);
                     float minwidth, maxwidth;
@@ -63,8 +64,7 @@ namespace KerbalAlarmClock
                 //On top of everything
                 GUI.depth = 0;
 
-                //update how long the tip has been on the screen and reset the flags
-                fltTooltipTime += Time.deltaTime;
+                //reset the flags
                 blnToolTipDisplayed = true;
             }
             else
@@ -72,7 +72,6 @@ namespace KerbalAlarmClock
                 //clear the flags
                 blnToolTipDisplayed = false;
             }
-            if (strToolTipText != strLastTooltipText) fltTooltipTime = 0f;
             strLastTooltipText = strToolTipText;
         }
 

--- a/KerbalAlarmClock/KerbalAlarmClock_Window.cs
+++ b/KerbalAlarmClock/KerbalAlarmClock_Window.cs
@@ -38,12 +38,11 @@ namespace KerbalAlarmClock
         Int32 intTooltipMaxWidth = 250;
         //timer so it only displays for a preriod of time
         float fltTooltipTime = 0f;
-        float fltMaxToolTipTime = 15f;
 
 
         private void DrawToolTip()
         {
-            if (strToolTipText != "" && (fltTooltipTime < fltMaxToolTipTime))
+            if (strToolTipText != "" && (fltTooltipTime < settings.MaxToolTipTimeFloat))
             {
                 GUIContent contTooltip = new GUIContent(strToolTipText);
                 if (!blnToolTipDisplayed || (strToolTipText != strLastTooltipText))

--- a/KerbalAlarmClock/KerbalAlarmClock_WindowSettings.cs
+++ b/KerbalAlarmClock/KerbalAlarmClock_WindowSettings.cs
@@ -228,6 +228,12 @@ namespace KerbalAlarmClock
             GUILayout.Label("Max alarms before scrolling the list", KACResources.styleAddHeading);
             GUILayout.EndHorizontal();
 
+            GUILayout.BeginHorizontal();
+            if(DrawTextBox(ref settings.MaxToolTipTime, KACResources.styleAddField, GUILayout.Width(45)))
+                settings.Save();
+            GUILayout.Label("Max time a Tooltip is visible", KACResources.styleAddHeading);
+            GUILayout.EndHorizontal();
+
             if (DrawCheckbox(ref settings.HideOnPause, "Hide Alarm Clock when game is paused"))
                 settings.Save();
 

--- a/KerbalAlarmClock/Settings.cs
+++ b/KerbalAlarmClock/Settings.cs
@@ -158,6 +158,18 @@ namespace KerbalAlarmClock
         }
 
 
+        [Persistent] internal String MaxToolTipTime = "15";
+        public float MaxToolTipTimeFloat
+        {
+            get
+            {
+                float v;
+                if(float.TryParse(MaxToolTipTime, out v))
+                    return v;
+                else
+                    return 15;
+            }
+        }
         [Persistent] internal Boolean ShowTooltips = true;
         [Persistent] internal Boolean ShowEarthTime = false;
 


### PR DESCRIPTION
I made MaxTooltipTime show up in the in-game configuration window. I also fixed a bug where the tooltip wasn't actually displaying for the length of time specified by MaxTooltipTime (since OnGui can get called multiple times per FixedUpdate the tooltip's time remaining could tick down faster than real-time, depending on your CPU, craft complexity, etc).