### PR TITLE
Replace some custom date/time formatting

### DIFF
--- a/KerbalAlarmClock/FrameworkExt/KSPDateStructure.cs
+++ b/KerbalAlarmClock/FrameworkExt/KSPDateStructure.cs
@@ -32,19 +32,19 @@ namespace KSPPluginFramework
         /// <summary>How many minutes make up an hour</summary>
         static public Int32 MinutesPerHour { get; private set; }
         /// <summary>How many hours make up a day</summary>
-        static public Int32 HoursPerDay { get; private set; }
+        static public double HoursPerDay { get; private set; }
         /// <summary>How many days make up a year</summary>
-        static public Int32 DaysPerYear { get; private set; }
+        static public double DaysPerYear { get; private set; }
 
         /// <summary>How many seconds (game UT) make up an hour</summary>
         static public Int32 SecondsPerHour { get { return SecondsPerMinute * MinutesPerHour; } }
         /// <summary>How many seconds (game UT) make up a day</summary>
-        static public Int32 SecondsPerDay { get { return SecondsPerHour * HoursPerDay; } }
+        static public double SecondsPerDay { get { return SecondsPerHour * HoursPerDay; } }
         /// <summary>How many seconds (game UT) make up a year - not relevant for Earth time</summary>
-        static public Int32 SecondsPerYear { get { return SecondsPerDay * DaysPerYear; } }
+        static public double SecondsPerYear { get { return SecondsPerDay * DaysPerYear; } }
 
         /// <summary>How many seconds (game UT) make up a year - not relevant for Earth time</summary>
-        static public Int32 HoursPerYear { get { return HoursPerDay * DaysPerYear; } }
+        static public double HoursPerYear { get { return HoursPerDay * DaysPerYear; } }
 
         
         /// <summary>What Earth date does UT 0 represent</summary>
@@ -63,8 +63,8 @@ namespace KSPPluginFramework
             SecondsPerMinute = 60;
             MinutesPerHour = 60;
 
-            HoursPerDay = GameSettings.KERBIN_TIME ? 6 : 24;
-            DaysPerYear = GameSettings.KERBIN_TIME ? 426 : 365;
+            HoursPerDay = KSPUtil.dateTimeFormatter.Day / 3600; // GameSettings.KERBIN_TIME ? 6 : 24;
+            DaysPerYear = KSPUtil.dateTimeFormatter.Year / KSPUtil.dateTimeFormatter.Day; // GameSettings.KERBIN_TIME ? 426 : 365;
         }
 
         /// <summary>Sets the Date Structure to be Earth based - Accepts Epoch date as string</summary>

--- a/KerbalAlarmClock/FrameworkExt/KSPDateTime.cs
+++ b/KerbalAlarmClock/FrameworkExt/KSPDateTime.cs
@@ -21,7 +21,7 @@ namespace KSPPluginFramework
 			get { if (CalType == CalendarTypeEnum.Earth) 
 				return _EarthDateTime.Year;
 			else
-				return KSPDateStructure.EpochYear + (Int32)UT / KSPDateStructure.SecondsPerYear; 
+				return KSPDateStructure.EpochYear + (Int32)(UT / KSPDateStructure.SecondsPerYear); 
 			}
 		}
 
@@ -31,7 +31,7 @@ namespace KSPPluginFramework
 			get { if (CalType == CalendarTypeEnum.Earth) 
 				return _EarthDateTime.DayOfYear;
 			else
-				return KSPDateStructure.EpochDayOfYear + (Int32)UT / KSPDateStructure.SecondsPerDay % KSPDateStructure.DaysPerYear; 
+				return KSPDateStructure.EpochDayOfYear + (Int32)(UT / KSPDateStructure.SecondsPerDay % KSPDateStructure.DaysPerYear); 
 			}
 		}
 
@@ -184,7 +184,7 @@ namespace KSPPluginFramework
 		{
 			//Test for entering values outside the norm - eg 25 hours, day 600
 
-			UT = new KSPTimeSpan((year - KSPDateStructure.EpochYear) * KSPDateStructure.DaysPerYear  +
+			UT = new KSPTimeSpan((Int32)((year - KSPDateStructure.EpochYear) * KSPDateStructure.DaysPerYear)  +
 								(day - KSPDateStructure.EpochDayOfYear),
 								hour,
 								minute,
@@ -261,12 +261,12 @@ namespace KSPPluginFramework
 				case DateStringFormatsEnum.KSPFormat:
 					return ToString();
 				case DateStringFormatsEnum.KSPFormatWithSecs:
-					return ToString("Year y, Da\\y d - H\\h, m\\m, s\\s");
+					return KSPUtil.dateTimeFormatter.PrintDate(UT, true, true); // ToString("Year y, Da\\y d - H\\h, m\\m, s\\s");
 				case DateStringFormatsEnum.DateTimeFormat:
                     if (KSPDateStructure.CalendarType==CalendarTypeEnum.Earth)
                         return ToString("d MMM yyyy, HH:mm:ss");
                     else
-					    return ToString("Year y, Da\\y d, HH:mm:ss");
+					    return KSPUtil.dateTimeFormatter.PrintDateCompact(UT, true, true); // ToString("Year y, Da\\y d, HH:mm:ss");
 				default:
 					return ToString();
 			}
@@ -279,7 +279,7 @@ namespace KSPPluginFramework
 			if (CalType ==CalendarTypeEnum.Earth) {
 				return ToString(System.Globalization.CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern + " " + System.Globalization.CultureInfo.CurrentCulture.DateTimeFormat.ShortTimePattern);
 			} else {
-				return ToString("Year y, Da\\y d - H\\h, m\\m", null);
+                return KSPUtil.dateTimeFormatter.PrintDate(UT, true, false); // ToString("Year y, Da\\y d - H\\h, m\\m", null);
 			}
 		}
 		/// <summary>Returns the string representation of the value of this instance.</summary> 

--- a/KerbalAlarmClock/FrameworkExt/KSPTimeSpan.cs
+++ b/KerbalAlarmClock/FrameworkExt/KSPTimeSpan.cs
@@ -28,7 +28,7 @@ namespace KSPPluginFramework
             {
                 if (CalType != CalendarTypeEnum.Earth)
                 {
-                    return (Int32)UT / KSPDateStructure.SecondsPerYear;
+                    return (Int32)(UT / KSPDateStructure.SecondsPerYear);
                 }
                 else
                 {
@@ -46,9 +46,9 @@ namespace KSPPluginFramework
         public Int32 Days {
             get {
                 if (CalType != CalendarTypeEnum.Earth) {
-                    return (Int32)UT / KSPDateStructure.SecondsPerDay % KSPDateStructure.DaysPerYear;
+                    return (Int32)(UT / KSPDateStructure.SecondsPerDay % KSPDateStructure.DaysPerYear);
                 } else {
-                    return (Int32)UT / KSPDateStructure.SecondsPerDay;
+                    return (Int32)(UT / KSPDateStructure.SecondsPerDay);
                 } 
             }
         }
@@ -56,7 +56,7 @@ namespace KSPPluginFramework
         /// <summary>Gets the hours component of the time interval represented by the current KSPPluginFramework.KSPTimeSpan structure.</summary> 
         /// <returns>The hour component of the current KSPPluginFramework.KSPTimeSpan structure. The return value ranges between +/- <see cref="KSPDateStructure.HoursPerDay"/></returns>
         public int Hours {
-            get { return (Int32)UT / KSPDateStructure.SecondsPerHour % KSPDateStructure.HoursPerDay; }
+            get { return (Int32)(UT / KSPDateStructure.SecondsPerHour % KSPDateStructure.HoursPerDay); }
         }
 
         /// <summary>Gets the minutes component of the time interval represented by the current KSPPluginFramework.KSPTimeSpan structure.</summary> 
@@ -183,19 +183,20 @@ namespace KSPPluginFramework
                 case TimeSpanStringFormatsEnum.DateTimeFormat:
                     return ToDateTimeString(Precision);
                 case TimeSpanStringFormatsEnum.IntervalLong:
-                    return ToString((UT < 0?"+ ":"") + "y Year\\s, d Da\\y\\s, hh:mm:ss");
+                    return (UT < 0 ? "+ " : "") + KSPUtil.dateTimeFormatter.PrintTimeLong(UT); // ToString((UT < 0?"+ ":"") + "y Year\\s, d Da\\y\\s, hh:mm:ss");
                 case TimeSpanStringFormatsEnum.IntervalLongTrimYears:
-                    return ToString((UT < 0 ? "+ " : "") + "y Year\\s, d Da\\y\\s, hh:mm:ss").Replace("0 Years, ", "");
+                    return (UT < 0 ? "+ " : "") + KSPUtil.dateTimeFormatter.PrintTimeLong(UT); // ToString((UT < 0 ? "+ " : "") + "y Year\\s, d Da\\y\\s, hh:mm:ss").Replace("0 Years, ", "");
                 case TimeSpanStringFormatsEnum.DateTimeFormatLong:
-                    String strFormat = "";
-                    if (Years > 0) strFormat += "y\\y";
-                    if (Days > 0) strFormat += (strFormat.EndsWith("y") ? ", ":"") + "d\\d";
-                    if (strFormat!="") strFormat += " ";
-                    strFormat += "hh:mm:ss";
+                    return (UT < 0 ? "+ " : "") + KSPUtil.dateTimeFormatter.PrintDateDeltaCompact(UT, true, true, true);
+                //String strFormat = "";
+                //if (Years > 0) strFormat += "y\\y";
+                //if (Days > 0) strFormat += (strFormat.EndsWith("y") ? ", ":"") + "d\\d";
+                //if (strFormat!="") strFormat += " ";
+                //strFormat += "hh:mm:ss";
 
-                    if (UT < 0) strFormat = "+ " + strFormat;
+                //if (UT < 0) strFormat = "+ " + strFormat;
 
-                    return ToString(strFormat);
+                //return ToString(strFormat);
                 default:
                     return ToString();
             }
@@ -213,45 +214,47 @@ namespace KSPPluginFramework
         /// <returns>A string that represents the value of this instance.</returns>
         public String ToString(Int32 Precision)
         {
-            Int32 Displayed = 0;
-            String format = "";
+            return (UT < 0 ? "+ " : "") + KSPUtil.dateTimeFormatter.PrintDateDeltaCompact(UT, Precision > 2, Precision >= 5, true);
 
-            if (UT < 0) format += "+";
+            //Int32 Displayed = 0;
+            //String format = "";
+
+            //if (UT < 0) format += "+";
 
 
-            if (CalType != CalendarTypeEnum.Earth) {
-                if ((Years != 0) && Displayed < Precision) {
-                    format = "y\\y,";
-                    Displayed++;
-                }
-            }
+            //if (CalType != CalendarTypeEnum.Earth) {
+            //    if ((Years != 0) && Displayed < Precision) {
+            //        format = "y\\y,";
+            //        Displayed++;
+            //    }
+            //}
 
-            if ((Days != 0 || format.EndsWith(",")) && Displayed < Precision)
-            {
-                format += (format == "" ? "" : " ") + "d\\d,";
-                Displayed++;
-            }
-            if ((Hours != 0 || format.EndsWith(",")) && Displayed < Precision)
-            {
-                format += (format==""?"":" ") + "h\\h,";
-                Displayed++;
+            //if ((Days != 0 || format.EndsWith(",")) && Displayed < Precision)
+            //{
+            //    format += (format == "" ? "" : " ") + "d\\d,";
+            //    Displayed++;
+            //}
+            //if ((Hours != 0 || format.EndsWith(",")) && Displayed < Precision)
+            //{
+            //    format += (format==""?"":" ") + "h\\h,";
+            //    Displayed++;
 
-            }
-            if ((Minutes != 0 || format.EndsWith(",")) && Displayed < Precision)
-            {
-                format += (format==""?"":" ") + "m\\m,";
-                Displayed++;
+            //}
+            //if ((Minutes != 0 || format.EndsWith(",")) && Displayed < Precision)
+            //{
+            //    format += (format==""?"":" ") + "m\\m,";
+            //    Displayed++;
 
-            }
-            if (Displayed<Precision) {
-                format += (format==""?"":" ") + "s\\s,";
-                Displayed++;
+            //}
+            //if (Displayed<Precision) {
+            //    format += (format==""?"":" ") + "s\\s,";
+            //    Displayed++;
 
-            }
+            //}
 
-            format = format.TrimEnd(',');
+            //format = format.TrimEnd(',');
 
-            return ToString(format, null);
+            //return ToString(format, null);
         }
 
         /// <summary>Returns the string representation of the value of this instance.</summary> 
@@ -259,48 +262,49 @@ namespace KSPPluginFramework
         /// <returns>A string that represents the value of this instance.</returns>
         public String ToDateTimeString(Int32 Precision)
         {
-            Int32 Displayed = 0;
-            String format = "";
+            return (UT < 0 ? "+ " : "") + KSPUtil.dateTimeFormatter.PrintDateDeltaCompact(UT, Precision > 2, Precision >= 5, true);
+            //Int32 Displayed = 0;
+            //String format = "";
 
-            if (UT < 0) format += "+ ";
+            //if (UT < 0) format += "+ ";
 
 
-            if (CalType != CalendarTypeEnum.Earth)
-            {
-                if ((Years != 0) && Displayed < Precision)
-                {
-                    format = "y\\y,";
-                    Displayed++;
-                }
-            }
+            //if (CalType != CalendarTypeEnum.Earth)
+            //{
+            //    if ((Years != 0) && Displayed < Precision)
+            //    {
+            //        format = "y\\y,";
+            //        Displayed++;
+            //    }
+            //}
 
-            if ((Days != 0 || format.EndsWith(",")) && Displayed < Precision)
-            {
-                format += (format == "" ? "" : " ") + "d\\d,";
-                Displayed++;
-            }
-            if ((Hours != 0 || format.EndsWith(",")) && Displayed < Precision)
-            {
-                format += (format == "" ? "" : " ") + "hh:";
-                Displayed++;
+            //if ((Days != 0 || format.EndsWith(",")) && Displayed < Precision)
+            //{
+            //    format += (format == "" ? "" : " ") + "d\\d,";
+            //    Displayed++;
+            //}
+            //if ((Hours != 0 || format.EndsWith(",")) && Displayed < Precision)
+            //{
+            //    format += (format == "" ? "" : " ") + "hh:";
+            //    Displayed++;
 
-            }
-            if (Displayed < Precision)
-            {
-                format += "mm:";
-                Displayed++;
+            //}
+            //if (Displayed < Precision)
+            //{
+            //    format += "mm:";
+            //    Displayed++;
 
-            }
-            if (Displayed < Precision)
-            {
-                format += "ss";
-                Displayed++;
+            //}
+            //if (Displayed < Precision)
+            //{
+            //    format += "ss";
+            //    Displayed++;
 
-            }
+            //}
 
-            format = format.TrimEnd(',').TrimEnd(':');
+            //format = format.TrimEnd(',').TrimEnd(':');
 
-            return ToString(format, null);
+            //return ToString(format, null);
         }
 
         /// <summary>Returns the string representation of the value of this instance.</summary> 

--- a/KerbalAlarmClock/KerbalAlarmClock.csproj
+++ b/KerbalAlarmClock/KerbalAlarmClock.csproj
@@ -40,14 +40,14 @@
   <ItemGroup>
     <Reference Include="Assembly-CSharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Squad\KSP\KSP\Library\ScriptAssemblies\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\KSP\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Squad\KSP\KSP\Library\UnityAssemblies\UnityEngine.dll</HintPath>
+      <HintPath>..\..\KSP\KSP_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -98,68 +98,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>rem Set the Variables we need
-echo Finding KSP
-
-rem if exist "R:\~Games\KSP_Win_PlugInTest_Minimal\KSP.exe" (
-rem 	set GAMEPATH="R:\~Games\KSP_Win_PlugInTest_Minimal"
-rem ) else if exist "D:\Programming\KSP\_Versions\KSP_win_PluginTest_Minimal\KSP.exe" (
-rem 	set GAMEPATH="D:\Programming\KSP\_Versions\KSP_Win_PlugInTest_Minimal"
-rem ) else if exist "C:\~Games\KSP_Win_PlugInTest_Minimal\KSP.exe" (
-rem 	set GAMEPATH="C:\~Games\KSP_Win_PlugInTest_Minimal
-rem ) else if exist "D:\Programming\KSP\_Versions\KSP_Win_PlugInTest\KSP.exe" (
-
-if exist "D:\Programming\KSP\_Versions\KSP_Win_PlugInTest\KSP.exe" (
-	set GAMEPATH="D:\Programming\KSP\_Versions\KSP_win_PluginTest"
-) else if exist "C:\~Games\KSP_Win_PlugInTest\KSP.exe" (
-	set GAMEPATH="C:\~Games\KSP_Win_PlugInTest"
-)else (
-	echo "Cant find KSP"
-	exit 1
-)
-
-echo Gamepath: %25GAMEPATH%25
-echo ConfigName: $(ConfigurationName)
-set DestPath="%25GAMEPATH%25\GameData\TriggerTech\KerbalAlarmClock"
-set Binary="%25GAMEPATH%25\KSP.exe"
-
-if not $(ConfigurationName)==Debug goto DEBUGREBUILDCONFIG
-:DEBUGCONFIG
-rem Copy DLL and run KSP
-copy "$(TargetPath)" "%25DestPath%25"
-rem and then run the game
-if exist "$(ProjectDir)..\..\StartX.exe" goto STARTX
-echo Running Directly
-"%25Binary%25"
-goto END
-
-:STARTX
-echo STARTX running
-"$(ProjectDir)..\..\StartX.exe" "%25Binary%25"
-goto END
-"%25Binary%25"
-
-goto END
-
-:DEBUGREBUILDCONFIG
-if not $(ConfigurationName)==DebugAndRebuild goto END
-rem This one will empty the dest folder and copy all the source files
-
-rem Delete the folder and recreate it
-rmdir /s /q "%25DestPath%25"
-mkdir "%25DestPath%25"
-
-rem Nowcopy all the files from the pluginfiles source
-xcopy "%25SourcePath%25\*.*" "%25DestPath%25" /SE
-rem and copy the new dll
-copy "$(TargetPath)" "%25DestPath%25"
-
-rem and then run the game
-"%25Binary%25"
-
-goto END
-
-:END</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/KerbalAlarmClock/TimeObjects.cs
+++ b/KerbalAlarmClock/TimeObjects.cs
@@ -418,18 +418,34 @@ namespace KerbalAlarmClock
         {
             get 
             {
-                //ZeroString(Years), 
-                Double result = new KSPTimeSpan(
-                    ZeroString(Days), 
-                    ZeroString(Hours), 
-                    ZeroString(Minutes), 
-                    ZeroString(Seconds)
-                    ).UT;
+                if (KSPDateStructure.CalendarType == CalendarTypeEnum.Earth)
+                {
 
-                if (Convert.ToInt32(ZeroString(Years)) != 0) { 
-                    result += Convert.ToInt32(ZeroString(Years))*KSPDateStructure.SecondsPerYear;
-                }
+                    //ZeroString(Years), 
+                    Double result = new KSPTimeSpan(
+                        ZeroString(Days),
+                        ZeroString(Hours),
+                        ZeroString(Minutes),
+                        ZeroString(Seconds)
+                        ).UT;
+
+                    if (Convert.ToInt32(ZeroString(Years)) != 0)
+                    {
+                        result += Convert.ToInt32(ZeroString(Years)) * KSPDateStructure.SecondsPerYear;
+                    }
                     return result;
+                }
+                else
+                {
+                    var tf = KSPUtil.dateTimeFormatter;
+                    Double result = tf.Year * Convert.ToInt32(ZeroString(Years))
+                        + tf.Day * Convert.ToInt32(ZeroString(Days))
+                        + tf.Hour * Convert.ToInt32(ZeroString(Hours))
+                        + tf.Minute * Convert.ToInt32(ZeroString(Minutes))
+                        + Convert.ToDouble(ZeroString(Seconds));
+                    return result;
+                }
+            
             }
         }
         private String ZeroString(String strInput)

--- a/KerbalAlarmClock/Utilities.cs
+++ b/KerbalAlarmClock/Utilities.cs
@@ -149,6 +149,7 @@ namespace KerbalAlarmClock
         {
             String strReturn = Input;
             //encode \r\t\n
+            strReturn = strReturn.Replace("\r\n", "\\r\\n");
             strReturn = strReturn.Replace("\r", "\\r");
             strReturn = strReturn.Replace("\n", "\\n");
             strReturn = strReturn.Replace("\t", "\\t");
@@ -159,7 +160,8 @@ namespace KerbalAlarmClock
         {
             String strReturn = Input;
             //encode \r\t\n
-            strReturn = strReturn.Replace("\\r", "\r");
+            strReturn = strReturn.Replace("\\r\\n", "\r\n");
+            strReturn = strReturn.Replace("\\r", "\r\n");
             strReturn = strReturn.Replace("\\n", "\n");
             strReturn = strReturn.Replace("\\t", "\t");
             return strReturn;


### PR DESCRIPTION
To help support non-standard day/year lengths from custom planet packs
or system rescales, prefer use of KSPUtil.dateTimeFormatter.

Tested against Kronometer with Rescale 6.4x and RSS with
RSSDateTimeFormatter

Known Issue: Setting raw time alarm using interval works correctly but
using date doesn't.