### PR TITLE
Bug/fix versioncheck

### DIFF
--- a/KerbalAlarmClock/KerbalAlarmClock.cs
+++ b/KerbalAlarmClock/KerbalAlarmClock.cs
@@ -471,7 +471,7 @@ namespace KerbalAlarmClock
 
 					//if we are adding the renderer and we are in flight then do the daily version check if required
 					if (HighLogic.LoadedScene == GameScenes.FLIGHT && settings.DailyVersionCheck)
-						settings.VersionCheck(false);
+						settings.VersionCheck(this, false);
 
 				}
 				else

--- a/KerbalAlarmClock/KerbalAlarmClock_WindowSettings.cs
+++ b/KerbalAlarmClock/KerbalAlarmClock_WindowSettings.cs
@@ -942,7 +942,7 @@ namespace KerbalAlarmClock
             GUILayout.FlexibleSpace();
             if (GUILayout.Button("Check Version Now", KACResources.styleButton))
             {
-                settings.VersionCheck(true);
+                settings.VersionCheck(this, true);
                 //Hide the flag as we already have the window open;
                 settings.VersionAttentionFlag = false;
             }

--- a/KerbalAlarmClock/Settings.cs
+++ b/KerbalAlarmClock/Settings.cs
@@ -389,47 +389,46 @@ namespace KerbalAlarmClock
         /// </summary>
         /// <param name="ForceCheck">Ignore all logic and simply do a check</param>
         /// <returns></returns>
-        public Boolean VersionCheck(Boolean ForceCheck)
+        public Boolean VersionCheck(MonoBehaviour parent, Boolean ForceCheck)
         {
             Boolean blnReturn = false;
             Boolean blnDoCheck = false;
 
             try
             {
-                if (ForceCheck)
+                if (!VersionCheckRunning)
                 {
-                    blnDoCheck = true;
-                    MonoBehaviourExtended.LogFormatted("Starting Version Check-Forced");
-                }
-                //else if (this.VersionWeb == "")
-                //{
-                //    blnDoCheck = true;
-                //    MonoBehaviourExtended.LogFormatted("Starting Version Check-No current web version stored");
-                //}
-                else if (this.VersionCheckDate_Attempt < DateTime.Now.AddYears(-9))
-                {
-                    blnDoCheck = true;
-                    MonoBehaviourExtended.LogFormatted("Starting Version Check-No current date stored");
-                }
-                else if (this.VersionCheckDate_Attempt.Date != DateTime.Now.Date)
-                {
-                    blnDoCheck = true;
-                    MonoBehaviourExtended.LogFormatted("Starting Version Check-stored date is not today");
+                    if (ForceCheck)
+                    {
+                        blnDoCheck = true;
+                        MonoBehaviourExtended.LogFormatted("Starting Version Check-Forced");
+                    }
+                    //else if (this.VersionWeb == "")
+                    //{
+                    //    blnDoCheck = true;
+                    //    MonoBehaviourExtended.LogFormatted("Starting Version Check-No current web version stored");
+                    //}
+                    else if (this.VersionCheckDate_Attempt < DateTime.Now.AddYears(-9))
+                    {
+                        blnDoCheck = true;
+                        MonoBehaviourExtended.LogFormatted("Starting Version Check-No current date stored");
+                    }
+                    else if (this.VersionCheckDate_Attempt.Date != DateTime.Now.Date)
+                    {
+                        blnDoCheck = true;
+                        MonoBehaviourExtended.LogFormatted("Starting Version Check-stored date is not today");
+                    }
+                    else
+                        MonoBehaviourExtended.LogFormatted("Skipping version check");
+
+                    if (blnDoCheck)
+                    {
+                        parent.StartCoroutine(crVersionCheck());
+                    }
                 }
                 else
-                    MonoBehaviourExtended.LogFormatted("Skipping version check");
+                    MonoBehaviourExtended.LogFormatted("Starting Version Check-version check already running");
 
-
-                if (blnDoCheck)
-                {
-                    //prep the background thread
-                    bwVersionCheck = new BackgroundWorker();
-                    bwVersionCheck.DoWork += bwVersionCheck_DoWork;
-                    bwVersionCheck.RunWorkerCompleted += bwVersionCheck_RunWorkerCompleted;
-
-                    //fire the worker
-                    bwVersionCheck.RunWorkerAsync();
-                }
                 blnReturn = true;
             }
             catch (Exception ex)
@@ -441,11 +440,10 @@ namespace KerbalAlarmClock
         }
 
         internal Boolean VersionCheckRunning = false;
-        BackgroundWorker bwVersionCheck;
-        WWW wwwVersionCheck;
-
-        void bwVersionCheck_DoWork(object sender, DoWorkEventArgs e)
+        private System.Collections.IEnumerator crVersionCheck()
         {
+            WWW wwwVersionCheck;
+
             //set initial stuff and save it
             VersionCheckRunning = true;
             this.VersionCheckResult = "Unknown - check again later";
@@ -455,12 +453,19 @@ namespace KerbalAlarmClock
             //now do the download
             MonoBehaviourExtended.LogFormatted("Reading version from Web");
             wwwVersionCheck = new WWW(VersionCheckURL);
-            while (!wwwVersionCheck.isDone) { }
-            MonoBehaviourExtended.LogFormatted("Download complete:{0}", wwwVersionCheck.text.Length);
+            yield return wwwVersionCheck;
+            if (wwwVersionCheck.error == null)
+            {
+                crVersionCheck_Completed(wwwVersionCheck);
+            }
+            else
+            {
+                MonoBehaviourExtended.LogFormatted("Version Download failed:{0}", wwwVersionCheck.error);
+            }
             VersionCheckRunning = false;
         }
 
-        void bwVersionCheck_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
+        void crVersionCheck_Completed(WWW wwwVersionCheck)
         {
             try
             {
@@ -497,7 +502,6 @@ namespace KerbalAlarmClock
             this.Save();
             VersionAttentionFlag = VersionAvailable;
         }
-
 
         //public Boolean getLatestVersion()
         //{
@@ -544,11 +548,11 @@ namespace KerbalAlarmClock
         //    MonoBehaviourExtended.LogFormatted("Version Check result:" + VersionCheckResult);
         //    return blnReturn;
         //}
-        #endregion
+#endregion
 
 
 
-        #region Sound Stuff
+#region Sound Stuff
         internal Boolean VerifySoundsList()
         {
             Boolean blnRet = false;
@@ -617,7 +621,7 @@ namespace KerbalAlarmClock
         }
     }
 
-	#endregion    
+#endregion
 
     internal class RectStorage:ConfigNodeStorage
     {


### PR DESCRIPTION
Ok, so not entirely sure why the commits are interleaved again; I tried to keep it neat and keep the bugfix and the project file changes separate. Anyhoo, let me know if you want them separated.

----

The actual bugfix commit (d32d78c) fixes an issue where KAC calls Unity APIs from a worker thread.  The error was logged in the debug build of the Unity player:
> InternalCreateBuffer can only be called from the main thread.

This error was raised because calling Unity APIs from threads other than the main thread is not allowed as per Unity spec. While it may -appear- to work in the release build of Unity, it can cause all sorts of issues. There's loads of discussions about this online; unfortunately I can't find the authoritative article on it at the moment.

The fix replaces the worker thread implementation with a Coroutine.

----

The other commits are completely optional, and modify the project files to be more user-friendly to contributors by keeping local paths outside the project file and placing them inside a ".user" file instead (a .user.template is added to the project for contributors to use as a basis).

----

Apart from this I'm happy to report that KAC seems to run perfectly well on KSP1.5.0.