### PR TITLE
Feature/build system improvements

### DIFF
--- a/KerbalAlarmClock/KerbalAlarmClock.csproj
+++ b/KerbalAlarmClock/KerbalAlarmClock.csproj
@@ -104,6 +104,13 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>rem Set the Variables we need
+if exist "$(PDB2MDB_TOOL)" (
+	echo Converting debug symbols...
+	"$(PDB2MDB_TOOL)" "$(TargetPath)"
+) else (
+	echo Couldn't find PDB2MDB tool "$(PDB2MDB_TOOL)"..
+)
+
 echo Finding KSP
 
 rem if exist "R:\~Games\KSP_Win_PlugInTest_Minimal\KSP.exe" (

--- a/KerbalAlarmClock/KerbalAlarmClock.csproj
+++ b/KerbalAlarmClock/KerbalAlarmClock.csproj
@@ -1,6 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <!-- Configuration Defaults; can be overridden in the .user file -->
+  <PropertyGroup>
+    <KSP_DIR>..\..\_Versions\KSP_win_PluginTest</KSP_DIR>
+    <PDB2MDB_TOOL>..\..\pdb2mdb.exe</PDB2MDB_TOOL>
+  </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -40,14 +45,14 @@
   <ItemGroup>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\_Versions\KSP_win_PluginTest\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(KSP_DIR)\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\_Versions\KSP_win_PluginTest\KSP_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(KSP_DIR)\KSP_x64_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -109,19 +114,22 @@ rem ) else if exist "C:\~Games\KSP_Win_PlugInTest_Minimal\KSP.exe" (
 rem 	set GAMEPATH="C:\~Games\KSP_Win_PlugInTest_Minimal
 rem ) else if exist "D:\Programming\KSP\_Versions\KSP_Win_PlugInTest\KSP.exe" (
 
-if exist "D:\Programming\KSP\_Versions\KSP_Win_PlugInTest\KSP.exe" (
+if exist "${KSP_DIR}\KSP_x64.exe" (
+	set GAMEPATH="${KSP_DIR}"
+) else if exist "D:\Programming\KSP\_Versions\KSP_Win_PlugInTest\KSP_x64.exe" (
 	set GAMEPATH="D:\Programming\KSP\_Versions\KSP_win_PluginTest"
-) else if exist "C:\~Games\KSP_Win_PlugInTest\KSP.exe" (
+) else if exist "C:\~Games\KSP_Win_PlugInTest\KSP_x64.exe" (
 	set GAMEPATH="C:\~Games\KSP_Win_PlugInTest"
 )else (
 	echo "Cant find KSP"
-	exit 1
+	rem Let's not fail the build if we can't auto-start the game...
+	exit 0
 )
 
 echo Gamepath: %25GAMEPATH%25
 echo ConfigName: $(ConfigurationName)
 set DestPath="%25GAMEPATH%25\GameData\TriggerTech\KerbalAlarmClock"
-set Binary="%25GAMEPATH%25\KSP.exe"
+set Binary="%25GAMEPATH%25\KSP_x64.exe"
 
 if not $(ConfigurationName)==Debug goto DEBUGREBUILDCONFIG
 :DEBUGCONFIG

--- a/KerbalAlarmClock/KerbalAlarmClock.csproj
+++ b/KerbalAlarmClock/KerbalAlarmClock.csproj
@@ -121,13 +121,13 @@ rem ) else if exist "C:\~Games\KSP_Win_PlugInTest_Minimal\KSP.exe" (
 rem 	set GAMEPATH="C:\~Games\KSP_Win_PlugInTest_Minimal
 rem ) else if exist "D:\Programming\KSP\_Versions\KSP_Win_PlugInTest\KSP.exe" (
 
-if exist "${KSP_DIR}\KSP_x64.exe" (
-	set GAMEPATH="${KSP_DIR}"
+if exist "$(KSP_DIR)\KSP_x64.exe" (
+	set GAMEPATH="$(KSP_DIR)"
 ) else if exist "D:\Programming\KSP\_Versions\KSP_Win_PlugInTest\KSP_x64.exe" (
 	set GAMEPATH="D:\Programming\KSP\_Versions\KSP_win_PluginTest"
 ) else if exist "C:\~Games\KSP_Win_PlugInTest\KSP_x64.exe" (
 	set GAMEPATH="C:\~Games\KSP_Win_PlugInTest"
-)else (
+) else (
 	echo "Cant find KSP"
 	rem Let's not fail the build if we can't auto-start the game...
 	exit 0
@@ -137,13 +137,18 @@ echo Gamepath: %25GAMEPATH%25
 echo ConfigName: $(ConfigurationName)
 set DestPath="%25GAMEPATH%25\GameData\TriggerTech\KerbalAlarmClock"
 set Binary="%25GAMEPATH%25\KSP_x64.exe"
+set DbgBinary="%25GAMEPATH%25\KSP_x64_Dbg.exe"
 
 if not $(ConfigurationName)==Debug goto DEBUGREBUILDCONFIG
 :DEBUGCONFIG
 rem Copy DLL and run KSP
 copy "$(TargetPath)" "%25DestPath%25"
+if exist "$(TargetPath).mdb" (
+	copy "$(TargetPath).mdb" "%25DestPath%25"
+)
 rem and then run the game
 if exist "$(ProjectDir)..\..\StartX.exe" goto STARTX
+if exist "%25DbgBinary%25" goto START_KSP_DBG
 echo Running Directly
 "%25Binary%25"
 goto END
@@ -152,8 +157,10 @@ goto END
 echo STARTX running
 "$(ProjectDir)..\..\StartX.exe" "%25Binary%25"
 goto END
-"%25Binary%25"
 
+:START_KSP_DBG
+echo START_KSP_DBG running
+"%25DbgBinary%25"
 goto END
 
 :DEBUGREBUILDCONFIG

--- a/KerbalAlarmClock/KerbalAlarmClock.csproj.user.template
+++ b/KerbalAlarmClock/KerbalAlarmClock.csproj.user.template
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- File: KerbalAlarmClock.csproj.user.template
+-
+- Copy this file to "KerbalAlarmClock.csproj.user" and edit according to your
+- development environment.
+-
+- Do NOT edit KerbalAlarmClock.csproj which is configured to the upstream authors'
+- environment.
+-
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <KSP_DIR>S:\KSP\KSP_Dev\</KSP_DIR>
+    <PDB2MDB_TOOL>S:\KSP\bin\pdb2mdb.exe</PDB2MDB_TOOL>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <StartAction>Program</StartAction>
+    <StartProgram>$(KSP_DIR)KSP_x64_Dbg.exe</StartProgram>
+    <StartWorkingDirectory>$(KSP_DIR)</StartWorkingDirectory>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <StartAction>Program</StartAction>
+    <StartProgram>$(KSP_DIR)\KSP_x64.exe</StartProgram>
+    <StartWorkingDirectory>$(KSP_DIR)</StartWorkingDirectory>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Suggested improvements and fixes to the project files used to build the plugin.

* Fixed paths to reference "KSP_x64..." as the 32-bit version is no longer available from 1.5 onwards.
* Use build variables for the paths (defaulting to the original authors').
* Supply a ".user.template" file for overriding the build variables without contributors having to modify the project file and accidentally submitting it.
* Optionally convert debug information to Unity format if the pd2mdb tool is available. (Can be used with the debug version of the Unity player).