### PR TITLE
Fix closest approach alarm to work when hyperbolic.

### DIFF
--- a/KerbalAlarmClock/KerbalAlarmClock_WindowAdd_Distance.cs
+++ b/KerbalAlarmClock/KerbalAlarmClock_WindowAdd_Distance.cs
@@ -65,6 +65,8 @@ namespace KerbalAlarmClock
 
                     double dblOrbitTestClosest = Double.MaxValue;
                     double dblOrbitTestClosestUT = 0;
+                    if (KACWorkerGameState.CurrentVessel.orbit.eccentricity > 1)
+                        intOrbits = 1;
                     for (int intOrbitToTest = 1; intOrbitToTest <= intOrbits; intOrbitToTest++)
                     {
                         dblOrbitTestClosestUT = KACUtils.timeOfClosestApproach(KACWorkerGameState.CurrentVessel.orbit,

--- a/KerbalAlarmClock/Utilities.cs
+++ b/KerbalAlarmClock/Utilities.cs
@@ -481,8 +481,16 @@ namespace KerbalAlarmClock
 
         internal static double timeOfClosestApproach(Orbit oOrig, Orbit oTgt, double timeStart, int orbit, out double closestdistance)
         {
+            double period = oOrig.period;
+            double start = timeStart + (orbit - 1) * period;
+            double len = period;
+            if (oOrig.eccentricity >= 1) {
+                start = timeStart;
+                len = oOrig.timeToPe + oTgt.period;
+                //UnityEngine.Debug.Log($"timeOfClosestApproach {start} {len} {ta} {E} {M} {Planetarium.GetUniversalTime ()}");
+            }
             //return timeOfClosestApproach(a, b, time + ((orbit - 1) * a.period), (orbit * a.period), 20, out closestdistance);
-            return timeOfClosestApproach(oOrig, oTgt, timeStart + ((orbit - 1) * oOrig.period), oOrig.period, 20, out closestdistance);
+            return timeOfClosestApproach(oOrig, oTgt, start, len, 20, out closestdistance);
         }
 
         internal static double timeOfClosestApproach(Orbit oOrig, Orbit oTgt, double timeStart, double periodtoscan, double numDivisions, out double closestdistance)


### PR DESCRIPTION
The old code used to work, but changes to Orbit in KSP 1.2 broke it because
the period for hyperbolas went from a negative number to infinity. Thus,
search only 1 "orbit" when hyperbolic (won't have a second chance) and
search from now until one *target* orbit period beyond own periapsis.