### PR TITLE
Fix erroneous blocking of input.

### DIFF
--- a/KerbalAlarmClock/KerbalAlarmClock.cs
+++ b/KerbalAlarmClock/KerbalAlarmClock.cs
@@ -1013,7 +1013,12 @@ namespace KerbalAlarmClock
 
 		private Boolean MouseOverWindow(Rect WindowRect, Boolean WindowVisible)
 		{
-			return WindowVisible && WindowRect.Contains(Event.current.mousePosition);
+			// Use Input instead of Event.current because Event.current.mousePosition
+			// gets inverted for key presses, but Input is stable (though always
+			// inverted).
+			Vector2 mousePos = Input.mousePosition;
+			mousePos.y = Screen.height - mousePos.y;
+			return WindowVisible && WindowRect.Contains(mousePos);
 		}
 
 #if DEBUG


### PR DESCRIPTION
The problem might be limited to linux, but Event.current.mousePosition gets
inverted for key-press events causing KAC to set input locks when a key is
pressed with the mouse in a region of the screen that would include a KAC
window when the Y axis is inverted. While Input.mousePosition is also
inverted, it is stable.