### PR TITLE
Pragmatic URI update

### DIFF
--- a/KerbalAlarmClock/Framework/ConfigNodeStorage.cs
+++ b/KerbalAlarmClock/Framework/ConfigNodeStorage.cs
@@ -1,7 +1,7 @@
 ﻿/* Part of KSPPluginFramework
 Version 1.2
 
-Forum Thread:http://forum.kerbalspaceprogram.com/threads/66503-KSP-Plugin-Framework
+Forum Thread:https://forum.kerbalspaceprogram.com/topic/60381-ksp-plugin-framework-plugin-examples-and-structure-v11-apr-6/
 Author: TriggerAu, 2014
 License: The MIT License (MIT)
 */

--- a/KerbalAlarmClock/Framework/ExtensionsUnity.cs
+++ b/KerbalAlarmClock/Framework/ExtensionsUnity.cs
@@ -1,7 +1,7 @@
 ﻿/* Part of KSPPluginFramework
 Version 1.2
 
-Forum Thread:http://forum.kerbalspaceprogram.com/threads/66503-KSP-Plugin-Framework
+Forum Thread:https://forum.kerbalspaceprogram.com/topic/60381-ksp-plugin-framework-plugin-examples-and-structure-v11-apr-6/
 Author: TriggerAu, 2014
 License: The MIT License (MIT)
 */

--- a/KerbalAlarmClock/Framework/MonoBehaviourExtended.cs
+++ b/KerbalAlarmClock/Framework/MonoBehaviourExtended.cs
@@ -1,7 +1,7 @@
 ﻿/* Part of KSPPluginFramework
 Version 1.2
 
-Forum Thread:http://forum.kerbalspaceprogram.com/threads/66503-KSP-Plugin-Framework
+Forum Thread:https://forum.kerbalspaceprogram.com/topic/60381-ksp-plugin-framework-plugin-examples-and-structure-v11-apr-6/
 Author: TriggerAu, 2014
 License: The MIT License (MIT)
 */
@@ -256,14 +256,14 @@ namespace KSPPluginFramework
         #endregion
 
         #region Standard Monobehaviour definitions-for overriding
-        //See this for info on order of execuction
-        //  http://docs.unity3d.com/Documentation/Manual/ExecutionOrder.html
+        //See this for info on order of execution
+        //  https://docs.unity3d.com/Manual/ExecutionOrder.html
 
         /// <summary>
         /// Unity Help: Awake is called when the script instance is being loaded.
         ///
         /// Trigger: Override this for initialization Code - this is before the Start Event
-        ///          See this for info on order of execuction: http://docs.unity3d.com/Documentation/Manual/ExecutionOrder.html
+        ///          See this for info on order of execution: https://docs.unity3d.com/Manual/ExecutionOrder.html
         /// </summary>
         internal virtual void Awake()
         {
@@ -274,7 +274,7 @@ namespace KSPPluginFramework
         /// Unity: Start is called on the frame when a script is enabled just before any of the Update methods is called the first time.
         ///
         /// Trigger: This is the last thing that happens before the scene starts doing stuff
-        ///          See this for info on order of execuction: http://docs.unity3d.com/Documentation/Manual/ExecutionOrder.html
+        ///          See this for info on order of execution: https://docs.unity3d.com/Manual/ExecutionOrder.html
         /// </summary>
         internal virtual void Start()
         {
@@ -285,7 +285,7 @@ namespace KSPPluginFramework
         /// Unity: This function is called every fixed framerate frame, if the MonoBehaviour is enabled.
         ///
         /// Trigger: This Update is called at a fixed rate and usually where you do all your physics stuff for consistent results
-        ///          See this for info on order of execuction: http://docs.unity3d.com/Documentation/Manual/ExecutionOrder.html
+        ///          See this for info on order of execution: https://docs.unity3d.com/Manual/ExecutionOrder.html
         /// </summary>
         internal virtual void FixedUpdate()
         { }
@@ -294,7 +294,7 @@ namespace KSPPluginFramework
         /// Unity: LateUpdate is called every frame, if the MonoBehaviour is enabled.
         ///
         /// Trigger: This Update is called just before the rendering, and where you can adjust any graphical values/positions based on what has been updated in the physics, etc
-        ///          See this for info on order of execuction: http://docs.unity3d.com/Documentation/Manual/ExecutionOrder.html
+        ///          See this for info on order of execution: https://docs.unity3d.com/Manual/ExecutionOrder.html
         /// </summary>
         internal virtual void LateUpdate()
         { }
@@ -308,7 +308,7 @@ namespace KSPPluginFramework
         /// 
         ///          NOTE: The class must be attached to a camera object to have this get called -  obj = MapView.MapCamera.gameObject.AddComponent<MBExtended>();
         /// 
-        ///          See this for info on order of execuction: http://docs.unity3d.com/Documentation/Manual/ExecutionOrder.html
+        ///          See this for info on order of execution: https://docs.unity3d.com/Manual/ExecutionOrder.html
         /// </summary>
         internal virtual void OnPreCull()
         { }
@@ -317,7 +317,7 @@ namespace KSPPluginFramework
         /// Unity: Update is called every frame, if the MonoBehaviour is enabled.
         ///
         /// Trigger: This is usually where you stick all your control inputs, keyboard handling, etc
-        ///          See this for info on order of execuction: http://docs.unity3d.com/Documentation/Manual/ExecutionOrder.html
+        ///          See this for info on order of execution: https://docs.unity3d.com/Manual/ExecutionOrder.html
         /// </summary>
         internal virtual void Update()
         { }
@@ -326,7 +326,7 @@ namespace KSPPluginFramework
         /// Unity Help: This function is called when the MonoBehaviour will be destroyed..
         ///
         /// Trigger: Override this for destruction and cleanup code
-        ///          See this for info on order of execuction: http://docs.unity3d.com/Documentation/Manual/ExecutionOrder.html
+        ///          See this for info on order of execution: https://docs.unity3d.com/Manual/ExecutionOrder.html
         /// </summary>
         internal virtual void OnDestroy()
         {

--- a/KerbalAlarmClock/KerbalAlarmClock_WindowAdd.cs
+++ b/KerbalAlarmClock/KerbalAlarmClock_WindowAdd.cs
@@ -1539,7 +1539,7 @@ namespace KerbalAlarmClock
                 GUILayout.Label("RSS detected - it is recommended that you use the Transfer Window Planner Plugin to plan transfers", KACResources.styleAddXferName);
                 GUILayout.Space(-8);
                 if (GUILayout.Button("Click here to open the TWP forum thread", KACResources.styleContent))
-                    Application.OpenURL("http://forum.kerbalspaceprogram.com/threads/93115");
+                    Application.OpenURL("https://forum.kerbalspaceprogram.com/topic/84005-14x-transfer-window-planner-v1630-march-18/");
                 intAddXferHeight += 58;
             }
 

--- a/KerbalAlarmClock/KerbalAlarmClock_WindowSettings.cs
+++ b/KerbalAlarmClock/KerbalAlarmClock_WindowSettings.cs
@@ -209,7 +209,7 @@ namespace KerbalAlarmClock
                 if (settings.ButtonStyleChosen == Settings.ButtonStyleEnum.Toolbar)
                 {
                     if (GUILayout.Button(new GUIContent("Not Installed. Click for Toolbar Info", "Click to open your browser and find out more about the Common Toolbar"), KACResources.styleContent))
-                        Application.OpenURL("http://forum.kerbalspaceprogram.com/threads/60863");
+                        Application.OpenURL("https://forum.kerbalspaceprogram.com/topic/161857-15-toolbar-continued-common-api-for-draggableresizable-buttons-toolbar/");
                     //intBlizzyToolbarMissingHeight = 18;
                 }
             }
@@ -789,7 +789,7 @@ namespace KerbalAlarmClock
             //    GUILayout.Label("Get the Common Toolbar:", KACResources.styleAddHeading);
             //    GUILayout.FlexibleSpace();
             //    if (GUILayout.Button("Click here", KACResources.styleContent))
-            //        Application.OpenURL("http://forum.kerbalspaceprogram.com/threads/60863");
+            //        Application.OpenURL("https://forum.kerbalspaceprogram.com/topic/161857-15-toolbar-continued-common-api-for-draggableresizable-buttons-toolbar/");
             //    GUILayout.EndHorizontal();
             //}
             //GUILayout.EndVertical();
@@ -996,11 +996,11 @@ namespace KerbalAlarmClock
             GUILayout.BeginVertical();
             //GUILayout.Label("Trigger Au",KACResources.styleContent);
             if (GUILayout.Button("Click Here", KACResources.styleContent))
-                Application.OpenURL("http://triggerau.github.io/KerbalAlarmClock/");
+                Application.OpenURL("https://triggerau.github.io/KerbalAlarmClock/");
             if (GUILayout.Button("Click Here", KACResources.styleContent))
-                Application.OpenURL("http://github.com/TriggerAu/KerbalAlarmClock/");
+                Application.OpenURL("https://github.com/TriggerAu/KerbalAlarmClock/");
             if (GUILayout.Button("Click Here", KACResources.styleContent))
-                Application.OpenURL("http://forum.kerbalspaceprogram.com/showthread.php/24786-Kerbal-Alarm-Clock");
+                Application.OpenURL("https://forum.kerbalspaceprogram.com/topic/22809-16x-kerbal-alarm-clock-v31000-dec-31/");
 
             GUILayout.EndVertical();
 
@@ -1025,7 +1025,7 @@ namespace KerbalAlarmClock
             GUILayout.BeginVertical();
             //GUILayout.Label("Trigger Au",KACResources.styleContent);
             if (GUILayout.Button("Import Instructions", KACResources.styleContent))
-                Application.OpenURL("http://triggerau.github.io/KerbalAlarmClock/install.html#AlarmImport");
+                Application.OpenURL("https://triggerau.github.io/KerbalAlarmClock/install.html#AlarmImport");
             GUILayout.EndVertical();
 
             GUILayout.EndHorizontal();

--- a/KerbalAlarmClock/Settings.cs
+++ b/KerbalAlarmClock/Settings.cs
@@ -347,7 +347,7 @@ namespace KerbalAlarmClock
         }
 
         #region Version Checks
-        private String VersionCheckURL = "http://triggerau.github.io/KerbalAlarmClock/versioncheck.txt";
+        private String VersionCheckURL = "https://triggerau.github.io/KerbalAlarmClock/versioncheck.txt";
         //Could use this one to see usage, but need to be very aware of data connectivity if its ever used "http://bit.ly/KACVersion";
 
         private String ConvertVersionCheckDateToString(DateTime Date)
@@ -518,7 +518,7 @@ namespace KerbalAlarmClock
 
         //        MonoBehaviourExtended.LogFormatted("Reading version from Web");
         //        //Page content FormatException is |LATESTVERSION|1.2.0.0|LATESTVERSION|
-        //        //WWW www = new WWW("http://kerbalalarmclock.codeplex.com/wikipage?title=LatestVersion");
+        //        //WWW www = new WWW("https://archive.codeplex.com/?p=kerbalalarmclock");
         //        WWW www = new WWW("https://sites.google.com/site/kerbalalarmclock/latestversion");
         //        while (!www.isDone) { }
 

--- a/KerbalAlarmClock/Utilities.cs
+++ b/KerbalAlarmClock/Utilities.cs
@@ -380,7 +380,7 @@ namespace KerbalAlarmClock
         //    return blnReturn;
         //}
 
-        //#region "AN/DN Code - predominantly the functions from the Kerbal Engineer Redux by cybutek under Creative commons BY-NC-SA - http://creativecommons.org/licenses/by-nc-sa/3.0/deed.en_GB"
+        //#region "AN/DN Code - predominantly the functions from the Kerbal Engineer Redux by cybutek under Creative commons BY-NC-SA - https://creativecommons.org/licenses/by-nc-sa/3.0/deed.en_GB"
         //public static Boolean CalcTimeToANorDN(Vector3d position, Orbit origin, Orbit target, ANDNNodeType typeOfNode, out Double timeToNode)
         //{
         //    timeToNode = 0d;

--- a/KerbalAlarmClock_APITester/Framework/ConfigNodeStorage.cs
+++ b/KerbalAlarmClock_APITester/Framework/ConfigNodeStorage.cs
@@ -1,7 +1,7 @@
 ﻿/* Part of KSPPluginFramework
 Version 1.2
 
-Forum Thread:http://forum.kerbalspaceprogram.com/threads/66503-KSP-Plugin-Framework
+Forum Thread:https://forum.kerbalspaceprogram.com/topic/60381-ksp-plugin-framework-plugin-examples-and-structure-v11-apr-6/
 Author: TriggerAu, 2014
 License: The MIT License (MIT)
 */

--- a/KerbalAlarmClock_APITester/Framework/ExtensionsUnity.cs
+++ b/KerbalAlarmClock_APITester/Framework/ExtensionsUnity.cs
@@ -1,7 +1,7 @@
 ﻿/* Part of KSPPluginFramework
 Version 1.2
 
-Forum Thread:http://forum.kerbalspaceprogram.com/threads/66503-KSP-Plugin-Framework
+Forum Thread:https://forum.kerbalspaceprogram.com/topic/60381-ksp-plugin-framework-plugin-examples-and-structure-v11-apr-6/
 Author: TriggerAu, 2014
 License: The MIT License (MIT)
 */

--- a/KerbalAlarmClock_APITester/Framework/MonoBehaviourExtended.cs
+++ b/KerbalAlarmClock_APITester/Framework/MonoBehaviourExtended.cs
@@ -1,7 +1,7 @@
 ﻿/* Part of KSPPluginFramework
 Version 1.2
 
-Forum Thread:http://forum.kerbalspaceprogram.com/threads/66503-KSP-Plugin-Framework
+Forum Thread:https://forum.kerbalspaceprogram.com/topic/60381-ksp-plugin-framework-plugin-examples-and-structure-v11-apr-6/
 Author: TriggerAu, 2014
 License: The MIT License (MIT)
 */
@@ -255,14 +255,14 @@ namespace KSPPluginFramework
         #endregion
 
         #region Standard Monobehaviour definitions-for overriding
-        //See this for info on order of execuction
-        //  http://docs.unity3d.com/Documentation/Manual/ExecutionOrder.html
+        //See this for info on order of execution
+        //  https://docs.unity3d.com/Manual/ExecutionOrder.html
 
         /// <summary>
         /// Unity Help: Awake is called when the script instance is being loaded.
         ///
         /// Trigger: Override this for initialization Code - this is before the Start Event
-        ///          See this for info on order of execuction: http://docs.unity3d.com/Documentation/Manual/ExecutionOrder.html
+        ///          See this for info on order of execution: https://docs.unity3d.com/Manual/ExecutionOrder.html
         /// </summary>
         internal virtual void Awake()
         {
@@ -273,7 +273,7 @@ namespace KSPPluginFramework
         /// Unity: Start is called on the frame when a script is enabled just before any of the Update methods is called the first time.
         ///
         /// Trigger: This is the last thing that happens before the scene starts doing stuff
-        ///          See this for info on order of execuction: http://docs.unity3d.com/Documentation/Manual/ExecutionOrder.html
+        ///          See this for info on order of execution: https://docs.unity3d.com/Manual/ExecutionOrder.html
         /// </summary>
         internal virtual void Start()
         {
@@ -284,7 +284,7 @@ namespace KSPPluginFramework
         /// Unity: This function is called every fixed framerate frame, if the MonoBehaviour is enabled.
         ///
         /// Trigger: This Update is called at a fixed rate and usually where you do all your physics stuff for consistent results
-        ///          See this for info on order of execuction: http://docs.unity3d.com/Documentation/Manual/ExecutionOrder.html
+        ///          See this for info on order of execution: https://docs.unity3d.com/Manual/ExecutionOrder.html
         /// </summary>
         internal virtual void FixedUpdate()
         { }
@@ -293,7 +293,7 @@ namespace KSPPluginFramework
         /// Unity: LateUpdate is called every frame, if the MonoBehaviour is enabled.
         ///
         /// Trigger: This Update is called just before the rendering, and where you can adjust any graphical values/positions based on what has been updated in the physics, etc
-        ///          See this for info on order of execuction: http://docs.unity3d.com/Documentation/Manual/ExecutionOrder.html
+        ///          See this for info on order of execution: https://docs.unity3d.com/Manual/ExecutionOrder.html
         /// </summary>
         internal virtual void LateUpdate()
         { }
@@ -307,7 +307,7 @@ namespace KSPPluginFramework
         /// 
         ///          NOTE: The class must be attached to a camera object to have this get called -  obj = MapView.MapCamera.gameObject.AddComponent<MBExtended>();
         /// 
-        ///          See this for info on order of execuction: http://docs.unity3d.com/Documentation/Manual/ExecutionOrder.html
+        ///          See this for info on order of execution: https://docs.unity3d.com/Manual/ExecutionOrder.html
         /// </summary>
         internal virtual void OnPreCull()
         { }
@@ -316,7 +316,7 @@ namespace KSPPluginFramework
         /// Unity: Update is called every frame, if the MonoBehaviour is enabled.
         ///
         /// Trigger: This is usually where you stick all your control inputs, keyboard handling, etc
-        ///          See this for info on order of execuction: http://docs.unity3d.com/Documentation/Manual/ExecutionOrder.html
+        ///          See this for info on order of execution: https://docs.unity3d.com/Manual/ExecutionOrder.html
         /// </summary>
         internal virtual void Update()
         { }
@@ -325,7 +325,7 @@ namespace KSPPluginFramework
         /// Unity Help: This function is called when the MonoBehaviour will be destroyed..
         ///
         /// Trigger: Override this for destruction and cleanup code
-        ///          See this for info on order of execuction: http://docs.unity3d.com/Documentation/Manual/ExecutionOrder.html
+        ///          See this for info on order of execution: https://docs.unity3d.com/Manual/ExecutionOrder.html
         /// </summary>
         internal virtual void OnDestroy()
         {

--- a/KerbalAlarmClock_APITester/Framework/MonoBehaviourWindow.cs
+++ b/KerbalAlarmClock_APITester/Framework/MonoBehaviourWindow.cs
@@ -1,7 +1,7 @@
 ﻿/* Part of KSPPluginFramework
 Version 1.2
 
-Forum Thread:http://forum.kerbalspaceprogram.com/threads/66503-KSP-Plugin-Framework
+Forum Thread:https://forum.kerbalspaceprogram.com/topic/60381-ksp-plugin-framework-plugin-examples-and-structure-v11-apr-6/
 Author: TriggerAu, 2014
 License: The MIT License (MIT)
 */
@@ -67,7 +67,7 @@ namespace KSPPluginFramework
         //}
 
         //TODO: Look at using this
-        //  http://answers.unity3d.com/questions/445444/add-component-in-one-line-with-parameters.html
+        //  https://answers.unity3d.com/questions/445444/add-component-in-one-line-with-parameters.html
 
         //internal static MonoBehaviourWindow CreateComponent(GameObject AttachTo)
         //{

--- a/KerbalAlarmClock_APITester/Framework/SkinsLibrary.cs
+++ b/KerbalAlarmClock_APITester/Framework/SkinsLibrary.cs
@@ -1,7 +1,7 @@
 ﻿/* Part of KSPPluginFramework
 Version 1.2
 
-Forum Thread:http://forum.kerbalspaceprogram.com/threads/66503-KSP-Plugin-Framework
+Forum Thread:https://forum.kerbalspaceprogram.com/topic/60381-ksp-plugin-framework-plugin-examples-and-structure-v11-apr-6/
 Author: TriggerAu, 2014
 License: The MIT License (MIT)
 */

--- a/PlugInFiles/GameData/TriggerTech/KerbalAlarmClock/PluginData/Data/data_TransferModelData.txt
+++ b/PlugInFiles/GameData/TriggerTech/KerbalAlarmClock/PluginData/Data/data_TransferModelData.txt
@@ -2,5 +2,5 @@
 
 Times and Phase angles for the first 101 years for All Hohmann transfers
 Calculated using the KSP Mission Control toolkit - http://forum.kerbalspaceprogram.com/showthread.php/40063-WIP-Mission-control-for-KSP-guide-for-basics-of-celestial-mechanics
-Link may no longer be valid since forum hiccup, alternate link is - http://www.reddit.com/r/KerbalSpaceProgram/comments/1bb9q0/calculated_interplanetary_transfer_phase_angles/
+Link is no longer valid since forum hiccup, alternate link is - https://www.reddit.com/r/KerbalSpaceProgram/comments/1bb9q0/calculated_interplanetary_transfer_phase_angles/
 Angles are valid for Kerbal Space Program 0.19.1

--- a/PlugInFiles/ReadMe-KerbalAlarmClock.txt
+++ b/PlugInFiles/ReadMe-KerbalAlarmClock.txt
@@ -4,9 +4,9 @@ How to stop Jeb from flying past his destination at Warp speed.
 
 By Trigger Au
 
-Forum Thread for latest: http://forum.kerbalspaceprogram.com/showthread.php/24786-Kerbal-Alarm-Clock
-Documentation Site: http://triggerau.github.io/KerbalAlarmClock/
-Install Instructions: http://triggerau.github.io/KerbalAlarmClock/install.html
+Forum Thread for latest: https://forum.kerbalspaceprogram.com/topic/22809-16x-kerbal-alarm-clock-v31000-dec-31/
+Documentation Site: https://triggerau.github.io/KerbalAlarmClock/
+Install Instructions: https://triggerau.github.io/KerbalAlarmClock/install.html
 
 INSTALLATION
 ******************* NOTE  ******************* NOTE ******************* NOTE *******************
@@ -29,7 +29,7 @@ LICENSE
 This work is licensed under an MIT license as outlined at the OSI site. Visit the documentation site for more details and Attribution
 
 ATTRIBUTION-SOUNDS
-Included Sounds are from freesfx.co.uk (http://www.freesfx.co.uk). EULA can be found here: http://www.freesfx.co.uk/info/eula/
+Included Sounds are from freesfx.co.uk (https://www.freesfx.co.uk). EULA can be found here: https://www.freesfx.co.uk/info/eula/
 
 VERSION HISTORY
 Version 3.10.0.0	-	KSP Version: 1.6.0
@@ -261,7 +261,7 @@ Version 3.0.1.0		-	KSP Version: 0.25.0
 - Restructure plugin folders
 - Added Alarm Import Tool for v2 Alarms
 - Added Flags
-- New documentation site - http://triggerau.github.io/KerbalAlarmClock/
+- New documentation site - https://triggerau.github.io/KerbalAlarmClock/
 - New versioncheck location on Github
 
 Version 2.7.9.0		-	KSP Version: 0.25.0
@@ -441,7 +441,7 @@ Version 1.3.3.0		-	KSP Version: 0.19.1
 - Tweaked Orbital Transfer lists
 
 Version 1.3.2.0		-	KSP Version: 0.18.4
-- Added Transfer Alarms - Alarms that can be set based on Hohmann transfers and formulas by Kosmo-Not used in Olex's calculator - http://kerbalspaceprogram.com/forum/showthread.php/16511-Interplanetary-How-To-Guide
+- Added Transfer Alarms - Alarms that can be set based on Hohmann transfers and formulas by Kosmo-Not used in Olex's calculator - https://forum.kerbalspaceprogram.com/topic/16413-tutorial-interplanetary-how-to-guide/
 - Added tooltips for more contextual info
 - Tweaked GUI to move interface flags and sizes
 - A number of general bugfixes

--- a/PluginBuilder/PublishKAC.ps1
+++ b/PluginBuilder/PublishKAC.ps1
@@ -279,7 +279,7 @@ if($ChoiceRtn -eq 0)
 	$reldescr = $reldescr.Replace("`r`n","\r\n")
 	$reldescr = $reldescr.Replace("`"","\`"")
 	
-    $ForumHeader = "[B][SIZE=4][COLOR=`"#FF0000`"]v$($Version) Now Available [/COLOR][/SIZE][/B]- [SIZE=3][B][URL=`"https://github.com/TriggerAu/$($GitHubName)/releases/tag/v$($Version)`"]Download from GitHub[/URL][/B] [/SIZE] or [SIZE=3][B][URL=`"http://kerbal.curseforge.com/ksp-mods/$($CurseName)/files`"]Download from Curse*[/URL][/B][/SIZE] or [SIZE=3][B][URL=`"https://kerbalstuff.com/mod/$($KerbalStuffModID)`"]Download from Kerbal Stuff[/URL][/B] [/SIZE]  [COLOR=`"#A9A9A9`"]* Once it's approved[/COLOR]"
+    $ForumHeader = "[B][SIZE=4][COLOR=`"#FF0000`"]v$($Version) Now Available [/COLOR][/SIZE][/B]- [SIZE=3][B][URL=`"https://github.com/TriggerAu/$($GitHubName)/releases/tag/v$($Version)`"]Download from GitHub[/URL][/B] [/SIZE] or [SIZE=3][B][URL=`"https://kerbal.curseforge.com/ksp-mods/$($CurseName)/files`"]Download from Curse*[/URL][/B][/SIZE] or [SIZE=3][B][URL=`"https://kerbalstuff.com/mod/$($KerbalStuffModID)`"]Download from Kerbal Stuff[/URL][/B] [/SIZE]  [COLOR=`"#A9A9A9`"]* Once it's approved[/COLOR]"
 
     $ForumList = "[LIST]`r`n" + $reldescr + "`r`n[/LIST]"
     $ForumList = $ForumList.Replace("\r\n","`r`n").Replace("`r`n* ","`r`n[*]")

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 KerbalAlarmClock
 ================
-A management and utility plugin for [Kerbal Space Program](http://www.kerbalspaceprogram.com/)
+A management and utility plugin for [Kerbal Space Program](https://www.kerbalspaceprogram.com/)
 
 The Kerbal Alarm Clock is a plugin that allows you to create reminder alarms at future periods to help you manage your flights and not warp past important times
 
-Forum Thread: [KerbalAlarmClock](http://forum.kerbalspaceprogram.com/threads/24786-Kerbal-Alarm-Clock)
+Forum Thread: [KerbalAlarmClock](https://forum.kerbalspaceprogram.com/topic/22809-16x-kerbal-alarm-clock-v31000-dec-31/)
 Author: TriggerAu


### PR DESCRIPTION
Link change reasons:
- Dead links to KSP forum before breakage updated with new URLs
- Redirects (including https) updated to destination path

Notable links that are still broken:
- http://bit.ly/KACVersion
- KSP Mission Control toolkit forum - can't find update :-(

Note also three very small typo/status changes ; no linting, style, or format changes