### PR TITLE
Fix drop-downs not working when UI scale != 100%

### DIFF
--- a/KerbalAlarmClock/KerbalAlarmClock.cs
+++ b/KerbalAlarmClock/KerbalAlarmClock.cs
@@ -599,15 +599,10 @@ namespace KerbalAlarmClock
 			//If the mainwindow is visible And no pause menu then draw it
 			if (WindowVisibleByActiveScene)
 			{
+				GUIUtility.ScaleAroundPivot(guiScale, Vector2.zero);
 				DrawWindowsPre();
-
-                // Set the scale for this run at stuff
-                GUIUtility.ScaleAroundPivot(guiScale, Vector2.zero);
-                DrawWindows();
-                GUIUtility.ScaleAroundPivot(Vector2.one, Vector2.zero);
-
-                DrawWindowsPost();
-
+				DrawWindows();
+				DrawWindowsPost();
 			}
 
 			if (settings.WarpToEnabled)


### PR DESCRIPTION
Moving the ScaleAroundPivot command ahead of DrawWindowsPre (and deleting the 'reset' command before DrawWindowsPost).  Previously, the drop-down menus (e.g. the styling selector) don't work when KSP's UI is scaled up or down.