### PR TITLE
Don't report missing vessel for null vessel IDs

### DIFF
--- a/KerbalAlarmClock/KerbalAlarmClock_WindowAlarm.cs
+++ b/KerbalAlarmClock/KerbalAlarmClock_WindowAlarm.cs
@@ -219,7 +219,7 @@ namespace KerbalAlarmClock
 		//Stuff to do with stored VesselIDs
 		private static void DrawStoredVesselIDMissing(String VesselID)
 		{
-			if (!StoredVesselExists(VesselID))
+			if (!(VesselID == null || VesselID == "") && !StoredVesselExists(VesselID))
 			{
 				GUILayout.Label("Stored VesselID no longer exists",KACResources.styleLabelWarning);
 			}


### PR DESCRIPTION
Currently if you set a manually specified date alarm from the spacecenter you'll get warning text in the alarm window that the stored vessel ID no longer exists, I assume because there is no associated vesselID.