### PR TITLE
Remove the outdated warning about copying over config.xml

### DIFF
--- a/PlugInFiles/ReadMe-KerbalAlarmClock.txt
+++ b/PlugInFiles/ReadMe-KerbalAlarmClock.txt
@@ -9,9 +9,6 @@ Documentation Site: https://triggerau.github.io/KerbalAlarmClock/
 Install Instructions: https://triggerau.github.io/KerbalAlarmClock/install.html
 
 INSTALLATION
-******************* NOTE  ******************* NOTE ******************* NOTE *******************
-IF YOU WANT TO MAINTAIN YOUR SETTINGS DO NOT COPY THE CONFIG.XML FILE OVER
-******************* NOTE  ******************* NOTE ******************* NOTE *******************
 
 Installing the plugin involves copying the plugin files into the correct location in the KSP aplication folder
 1. Extract the Zip file you have downloaded to a temporary Location

--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ A management and utility plugin for [Kerbal Space Program](http://www.kerbalspac
 
 The Kerbal Alarm Clock is a plugin that allows you to create reminder alarms at future periods to help you manage your flights and not warp past important times
 
-Forum Thread: [KerbalAlarmClock](http://forum.kerbalspaceprogram.com/threads/24786-Kerbal-Alarm-Clock)
+Forum Thread: [KerbalAlarmClock](https://forum.kerbalspaceprogram.com/index.php?/topic/22809-16x-kerbal-alarm-clock)
 Author: TriggerAu


### PR DESCRIPTION
I rarely upgrade, and each time I do it this warning makes me (needlessly) stop and check... :-)